### PR TITLE
Documentation improvements: Fix outdated links and grammar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
 # Breaking Changes in v7.0
 
-- ParameterizedFunctions.jl, along with a few other modeling libraries, are no 
-  longer exported by DifferentialEquations.jl. You must do `using ParameterizedFunctions` 
+- ParameterizedFunctions.jl, along with a few other modeling libraries, are no
+  longer exported by DifferentialEquations.jl. You must do `using ParameterizedFunctions`
   to use the `@ode_def macro. As it has not been part of the documentation for 3 years,
-  this is breaking but should not effect most users. This reduces the dependencies and
+  this is breaking but should not affect most users. This reduces the dependencies and
   using time of the library by about half.
 - OrdinaryDiffEq.jl has a new linear solver system based on the LinearSolve.jl library.
   `linsolve` arguments now take LinearSolve.jl solvers.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Additionally, DifferentialEquations.jl comes with built-in analysis features, in
 - [Parameter Estimation and Bayesian Analysis](https://docs.sciml.ai/Overview/stable/highlevels/inverse_problems/)
 - Neural differential equations with [DiffEqFlux.jl](https://docs.sciml.ai/DiffEqFlux/stable/)
   for efficient scientific machine learning (scientific ML) and scientific AI.
-- Automatic distributed, multithreaded, and GPU [Parallel Ensemble Simulations](https://diffeq.sciml.ai/dev/features/ensemble/)
+- Automatic distributed, multithreaded, and GPU [Parallel Ensemble Simulations](https://docs.sciml.ai/DiffEqDocs/stable/features/ensemble/)
 - [Global Sensitivity Analysis](https://docs.sciml.ai/GlobalSensitivity/stable/)
 - [Uncertainty Quantification](https://docs.sciml.ai/Overview/stable/highlevels/uncertainty_quantification/)
 
@@ -72,8 +72,8 @@ This gives a powerful mixture of speed and productivity features to help you
 solve and analyze your differential equations faster.
 
 For information on using the package,
-[see the stable documentation](https://diffeq.sciml.ai/stable/). Use the
-[in-development documentation](https://diffeq.sciml.ai/dev/) for the version of
+[see the stable documentation](https://docs.sciml.ai/DiffEqDocs/stable/). Use the
+[in-development documentation](https://docs.sciml.ai/DiffEqDocs/dev/) for the version of
 the documentation which contains the unreleased features.
 
 All of the algorithms are thoroughly tested to ensure accuracy via convergence
@@ -85,10 +85,10 @@ Benchmarks
 If you find any equation where there seems to be an error, please open an issue.
 
 If you have any questions, or just want to chat about solvers/using the package,
-please feel free to chat in the [Gitter channel](https://gitter.im/JuliaDiffEq/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge).
+please feel free to chat in the [Zulip channel](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged).
 For bug reports, feature requests, etc., please submit an issue. If you're
 interested in contributing, please see the
-[Developer Documentation](http://devdocs.sciml.ai/latest/).
+[Developer Documentation](https://devdocs.sciml.ai/latest/).
 
 ## Supporting and Citing
 
@@ -97,7 +97,7 @@ would like to help support it, please star the repository, as such metrics may
 help us secure funding in the future. If you use SciML software as part
 of your research, teaching, or other activities, we would be grateful if you
 could cite our work.
-[Please see our citation page for guidelines](http://sciml.ai/citing.html).
+[Please see our citation page for guidelines](https://sciml.ai/citing.html).
 
 --------------------------------
 


### PR DESCRIPTION
## Summary

This PR fixes several documentation issues found in README.md and NEWS.md:

- **Updated outdated Gitter link to Zulip**: The README referenced an old Gitter channel, but the project now uses Zulip (which is already linked at the top of the README)
- **Fixed deprecated documentation URLs**: Updated `diffeq.sciml.ai` links to the current `docs.sciml.ai/DiffEqDocs` domain (3 links updated)
- **Security improvement**: Changed `http://` to `https://` for devdocs.sciml.ai and sciml.ai links
- **Grammar fix**: Corrected "effect" to "affect" in NEWS.md

All changes are minor corrections that improve documentation accuracy and consistency without changing any functionality.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)