### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
+[files]
+extend-exclude = ["assets/*.svg"]
+
 [default.extend-words]
 # Julia-specific functions
 indexin = "indexin"

--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-OrdinaryDiffEq = "6.53"
+OrdinaryDiffEq = "6.53, 7"
 Reexport = "1.0"
-SciMLBase = "2.51"
+SciMLBase = "2.51, 3"
 julia = "1.10"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ using DifferentialEquations, Test, SafeTestsets
                 du[3] = k₂ * y₂^2
             end
             prob = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1e5), (0.04, 3e7, 1e4))
-            sol = solve(prob, Rodas5())
+            sol = solve(prob, Rodas5P())
             @test sol.retcode == ReturnCode.Success
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using DifferentialEquations, Test, SafeTestsets
             u0 = 0.5
             tspan = (0.0, 1.0)
             prob = ODEProblem(f, u0, tspan)
-            sol = solve(prob, Tsit5(), reltol = 1e-8, abstol = 1e-8)
+            sol = solve(prob, Tsit5(), reltol = 1.0e-8, abstol = 1.0e-8)
             @test sol.retcode == ReturnCode.Success
             @test length(sol.t) > 0
             @test length(sol.u) > 0
@@ -45,7 +45,7 @@ using DifferentialEquations, Test, SafeTestsets
                 du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
                 du[3] = k₂ * y₂^2
             end
-            prob = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1e5), (0.04, 3e7, 1e4))
+            prob = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
             sol = solve(prob, Rodas5P())
             @test sol.retcode == ReturnCode.Success
         end


### PR DESCRIPTION
## Summary

Prepares DifferentialEquations.jl for the OrdinaryDiffEq v7 / SciMLBase v3 ecosystem release.

- **`Project.toml`**: Widen compat bounds to accept both the current and new majors:
  - `OrdinaryDiffEq = "6.53"` → `"6.53, 7"`
  - `SciMLBase = "2.51"` → `"2.51, 3"`
- **`test/runtests.jl`**: Migrate stiff ODE test from `Rodas5()` to `Rodas5P()`. `Rodas5` is no longer re-exported from the OrdinaryDiffEq v7 top-level meta-package (only `Rodas5P` is in the default set); `Rodas5P` is available and recommended in both v6 and v7.

## References

- SciML/OrdinaryDiffEq.jl#3562 — Cascade major version bump across all sublibs
- SciML/OrdinaryDiffEq.jl#3565 — Revert OrdinaryDiffEqCore and DiffEqDevTools major bumps
- [OrdinaryDiffEq.jl NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)

## Test plan

- [x] `Pkg.test()` passes locally with OrdinaryDiffEq v6 / SciMLBase v2 (all 17 tests pass)
- [ ] CI green with current ecosystem (v6/v2)
- [ ] CI green once OrdinaryDiffEq v7 / SciMLBase v3 are registered in General

🤖 Generated with [Claude Code](https://claude.com/claude-code)