### PR TITLE
Centralize CI to SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,20 +12,9 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI workflows to the centralized `SciML/.github` reusable workflow callers (all pinned `@v1`, every caller gets `secrets: "inherit"`). Matches the Sundials.jl end-state.

## Converted (inline -> central)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline `julia-actions/julia-downgrade-compat` -> `downgrade.yml@v1` (preserves `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`)

## Unchanged
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` and the `1`/`lts`/`pre` version matrix — left exactly as-is.
- **TagBot.yml**: unchanged.

## Added callers
- None. The repo already had Tests, Runic (FormatCheck), SpellCheck, and Downgrade. No `docs/` dir, so no Documentation caller. No existing Downstream/Benchmark/CompatHelper workflows.

## Other changes
- **dependabot.yml**: removed the `crate-ci/typos` version-update ignore (typos version is now pinned/managed by the central spellcheck workflow). The `github-actions` (weekly, `/`) and `julia` (daily, group `all-julia-packages: ["*"]`, dirs `/` and `/test`) blocks are preserved.

## Checks
- Typos: ran `typos .` -> exit 0 (clean), no changes needed. Existing `.typos.toml` preserved.
- Runic: installed Runic v1.7.0 and ran `--inplace .` -> no formatting changes (repo was already Runic-clean from the prior inline check).
- All changed YAML validated with `yaml.safe_load`.

## Note on branch protection
The job/check names change when moving to reusable workflows (e.g. `runic` -> the reusable workflow's `Runic Format Check`, `typos-check` -> `Spell Check with Typos`, Downgrade `test` -> `Downgrade Tests`). Required status checks in branch protection will need to be updated to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)