### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/src/DifferentialEquations.jl
+++ b/src/DifferentialEquations.jl
@@ -1,6 +1,8 @@
 module DifferentialEquations
 
-using Reexport
+using Reexport: Reexport, @reexport
+import SciMLBase
+import OrdinaryDiffEq
 
 @reexport using SciMLBase
 @reexport using OrdinaryDiffEq

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ DifferentialEquations = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,7 @@
-using DifferentialEquations
-using Aqua: Aqua
-using JET: JET
-using Test
+using SciMLTesting, DifferentialEquations, JET, Test
 
-@testset "Aqua.jl" begin
-    Aqua.test_all(DifferentialEquations)
-end
-
-@testset "JET.jl" begin
-    JET.test_package(DifferentialEquations, target_defined_modules = true)
-end
+run_qa(
+    DifferentialEquations;
+    explicit_imports = true,
+    jet_kwargs = (; target_defined_modules = true),
+)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA group onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled.

## What changed
- `test/qa/qa.jl`: replaced the hand-rolled `Aqua.test_all` + `JET.test_package` body with `run_qa(DifferentialEquations; explicit_imports = true, jet_kwargs = (; target_defined_modules = true))`. Aqua + ExplicitImports come from SciMLTesting's own deps; JET stays opt-in via `using JET`. The prior JET `target_defined_modules = true` behavior is preserved.
- `src/DifferentialEquations.jl`: made the module-level implicit imports explicit so `no_implicit_imports` passes — `using Reexport: Reexport, @reexport` plus `import SciMLBase` / `import OrdinaryDiffEq`. The two `@reexport using ...` lines are unchanged, so all re-exports remain intact.
- `test/qa/Project.toml`: `SciMLTesting` compat → `"1.6"`. Aqua kept as a direct dep (Aqua's ambiguities child-process needs it directly); JET and SafeTestsets kept (SafeTestsets is required directly by the `run_tests` folder model's `@safetestset` wrapping on Julia 1.10). ExplicitImports is transitive via SciMLTesting and is not listed.

## ExplicitImports findings
All 6 EI checks are **green** after the source fix. The only finding was `no_implicit_imports` (the bare `using Reexport` / `@reexport using SciMLBase` / `@reexport using OrdinaryDiffEq` relied on implicit module names). Since there were only 4 such names and they are easy to make explicit, they were fixed rather than `ei_broken`-tracked. No ignore-lists were needed. No `aqua_broken` / `jet_broken` / `ei_broken` markers (the prior qa.jl had none to preserve).

## Local verification (released SciMLTesting 1.6.0, Julia 1.10, clean depot)
- QA group via `GROUP=QA test/runtests.jl`: **18/18 pass**, 0 fail/error/broken.
  - Breakdown: Aqua 11, JET 1, ExplicitImports 6 (all checks pass).
- Re-export sanity + ODE solve smoke test: `ODEProblem`/`solve`/`Tsit5`/`Rodas5P`/`ReturnCode`/... all present; solve returns `ReturnCode.Success`.
- Core group via `Pkg.test()`: **17/17 pass** (confirms the `src/` change does not regress).
- Runic-clean on both changed `.jl` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)