### PR TITLE
Allow SciMLTesting v2 in compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Random = "1"
 Reexport = "1.0"
 SafeTestsets = "0.1"
 SciMLBase = "2.51, 3"
-SciMLTesting = "1"
+SciMLTesting = "1, 2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ DifferentialEquations = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "1, 0.1"
-SciMLTesting = "1.6"
+SciMLTesting = "1.6, 2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary
- Expand root `SciMLTesting` compat from `"1"` to `"1, 2.1"`.
- Expand `test/qa` `SciMLTesting` compat from `"1.6"` to `"1.6, 2.1"`.
- SciMLTesting v2 QA passed without package-owned public docstring fixes or QA exceptions.

Ignored until reviewed by @ChrisRackauckas.

## Local verification
All Julia commands used `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/julia_depots/DifferentialEquations` and `timeout 3600`.

- `timeout 3600 git diff --check`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using TOML; root = TOML.parsefile("Project.toml"); qa = TOML.parsefile("test/qa/Project.toml"); @assert root["compat"]["SciMLTesting"] == "1, 2.1"; @assert qa["compat"]["SciMLTesting"] == "1.6, 2.1"; println("SciMLTesting compat assertions passed")'`\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/julia_envs/diffeq_runic -e 'using Runic; exit(Runic.main(["--check", "."]))'` with Runic v1.7.0\n- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test(coverage=false)'` selected SciMLTesting v2.2.0 and passed: `QA/qa.jl | 17 17 | 10m39.6s`\n- `GROUP=All timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test(coverage=false)'` selected SciMLTesting v2.2.0 and passed: `Core/core.jl | 17 17 | 20.5s`\n