### PR TITLE
Restrict SciMLTesting compat to v2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Random = "1"
 Reexport = "1.0"
 SafeTestsets = "0.1"
 SciMLBase = "2.51, 3"
-SciMLTesting = "1, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ DifferentialEquations = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "1, 0.1"
-SciMLTesting = "1.6, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary
- restrict the root SciMLTesting compat entry from `1, 2.1` to exactly `2.1`
- restrict the QA SciMLTesting compat entry from `1.6, 2.1` to exactly `2.1`
- leave source, docs, tests, and unrelated setup unchanged

## Validation
- `git diff --check`
- Runic.jl 1.7.0 with Julia 1.10.11 on `src` and `test`
- `julia +1.10 --project=. -e "using Pkg; Pkg.instantiate(); include(\"test/core.jl\")"` with repo-local depot: 17/17 pass
- `julia +1.10 --project=test/qa -e "using Pkg; Pkg.instantiate(); include(\"test/qa/qa.jl\")"` with repo-local depot: 17/17 pass

Generated manifests, local tool envs, and local depots were removed before commit.

## PR state
This was requested as a draft/ignore-until-reviewed PR. It was merged by @ChrisRackauckas at 2026-07-15T10:32:00Z before the later draft-state correction attempt, so the final PR state is merged rather than draft.