### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,14 @@
 using SciMLTesting, DifferentialEquations, JET, Test
 
+# Only dependency-owned reexports are ignored; any owned public name must render.
+const DEPENDENCY_OWNED_REEXPORTS = Tuple(
+    name for name in public_api_names(DifferentialEquations)
+        if parentmodule(getfield(DifferentialEquations, name)) !== DifferentialEquations
+)
+
 run_qa(
     DifferentialEquations;
+    api_docs_kwargs = (; rendered = true, rendered_ignore = DEPENDENCY_OWNED_REEXPORTS),
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
 )


### PR DESCRIPTION
## Summary

This PR enables SciMLTesting rendered public API docs QA for DifferentialEquations.jl. DifferentialEquations.jl is a meta package whose current public names are dependency-owned reexports, so the rendered ignore set is derived from names whose bindings are not owned by `DifferentialEquations` itself. Any future package-owned public name will still need rendered docs.

Ignore this PR until reviewed by @ChrisRackauckas.

## Validation

- `git diff --check`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/toolenvs/runic -e 'using Runic; exit(Runic.main(["--check", "test/qa/qa.jl"]))'`\n- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` (`QA/qa.jl | 18 pass | 1m08.6s`)\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` (`Core/core.jl | 17 pass | 23.6s`)\n\nDocs build was not run because this repository has no `docs/` directory.