### PR TITLE
Drop older SciML major versions from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,11 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-OrdinaryDiffEq = "6.53, 7"
+OrdinaryDiffEq = "7"
 Random = "1"
 Reexport = "1.0"
 SafeTestsets = "0.1"
-SciMLBase = "2.51, 3"
+SciMLBase = "3"
 SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop older major versions of SciML packages**. For each SciML dependency, only the current major remains (existing lower bound on that major is kept). No code, tests, or package version were changed.

- `Project.toml` [deps] `OrdinaryDiffEq`: `6.53, 7` → `7` (drop 6.53; current SciML major is 7)
- `Project.toml` [deps] `SciMLBase`: `2.51, 3` → `3` (drop 2.51; current SciML major is 3)

## Why

Supporting multiple SciML majors keeps untested resolver windows. The current major is the one in the General registry; older majors are dropped even when that current major is recent.

## Verification

Current majors come from JuliaRegistries/General `Versions.toml`. Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
