### PR TITLE
Update QA for current SciMLTesting/JET defaults

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -6,8 +6,11 @@ const NONMODULE_REEXPORTS = (
     :AffineOperator,
     :AllObserved,
     :AnalyticalProblem,
+    :AutoDePSpecialize,
+    :AutoDespecialize,
     :AutoFiniteDiff,
     :AutoForwardDiff,
+    :AutoRespecialize,
     :AutoSparse,
     :AutoTsit5,
     :AutoVern6,
@@ -28,6 +31,7 @@ const NONMODULE_REEXPORTS = (
     :DDEFunction,
     :DDEProblem,
     :DefaultODEAlgorithm,
+    :DEVerbosity,
     :DiagonalOperator,
     :DiscreteCallback,
     :DiscreteFunction,
@@ -215,6 +219,5 @@ const INTENTIONAL_REEXPORTS = (
 run_qa(
     DifferentialEquations;
     api_docs_kwargs = (; rendered_ignore = NONMODULE_REEXPORTS),
-    jet_kwargs = (; target_defined_modules = true),
     reexports_allow = INTENTIONAL_REEXPORTS,
 )


### PR DESCRIPTION
## What changed

- Remove the deprecated `target_defined_modules = true` JET override; SciMLTesting now supplies the package target and `:typo` mode by default.
- Add four dependency-owned names to the existing intentional facade re-export allowlist: `AutoDePSpecialize`, `AutoDespecialize`, `AutoRespecialize`, and `DEVerbosity`.

The re-export entries are intentional because DifferentialEquations is an `@reexport` facade over SciMLBase and OrdinaryDiffEq. No QA checks were disabled or marked broken.

## Verification

Clean `upstream/master` at `e17b8cb`, before the change:

```text
$ julia --project=test/qa test/qa/qa.jl
JET warning: `target_defined_modules::Bool` configuration is deprecated.
Test Summary: Quality Assurance | 20 passed, 1 failed, 21 total
Failure: No unapproved public reexports: AutoDePSpecialize, AutoDespecialize, AutoRespecialize, DEVerbosity
```

After the change:

```text
$ julia --project=test/qa test/qa/qa.jl
Test Summary:     | Pass  Total   Time
Quality Assurance |   21     21  42.7s

$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'\nTest Summary: | Pass  Total   Time\nQA/qa.jl      |   21     21  58.2s\n\n$ julia --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/runic_env -m Runic --check --diff test/qa/qa.jl\n$ typos test/qa/qa.jl\n$ git diff --check\n```\n\nThe formatter, spelling, and diff checks exited successfully with no output.\n\nPlease ignore this draft until reviewed by @ChrisRackauckas.\n\n## Links\n\n- Branch commit: https://github.com/ChrisRackauckas-Claude/DifferentialEquations.jl/commit/83977c7\n