### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,13 @@ version = "8.0.3"
 
 [deps]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 OrdinaryDiffEq = "7"
+PrecompileTools = "1"
 Random = "1"
 Reexport = "1.0"
 SafeTestsets = "0.1"

--- a/src/DifferentialEquations.jl
+++ b/src/DifferentialEquations.jl
@@ -1,10 +1,32 @@
 module DifferentialEquations
 
 using Reexport: Reexport, @reexport
+using PrecompileTools: @compile_workload, @setup_workload
 import SciMLBase
 import OrdinaryDiffEq
 
 @reexport using SciMLBase
 @reexport using OrdinaryDiffEq
+
+@setup_workload begin
+    scalar_problem = ODEProblem((u, p, t) -> p * u, 0.5, (0.0, 1.0), 1.01)
+    stiff_problem = ODEProblem(
+        (du, u, p, t) -> begin
+            y₁, y₂, y₃ = u
+            k₁, k₂, k₃ = p
+            du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
+            du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
+            du[3] = k₂ * y₂^2
+        end,
+        [1.0, 0.0, 0.0],
+        (0.0, 1.0),
+        (0.04, 3.0e7, 1.0e4)
+    )
+
+    @compile_workload begin
+        solve(scalar_problem, Tsit5())
+        solve(stiff_problem, Rodas5P())
+    end
+end
 
 end # module


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.